### PR TITLE
feat: add resilient REST client and data service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Build with Maven
+        run: mvn -q -e install

--- a/tsheets-core/pom.xml
+++ b/tsheets-core/pom.xml
@@ -30,6 +30,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/tsheets-core/src/main/java/com/intuit/tsheets/api/DataService.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/api/DataService.java
@@ -1,0 +1,23 @@
+package com.intuit.tsheets.api;
+
+import com.intuit.tsheets.client.ResilientRestClient;
+import com.intuit.tsheets.config.DataServiceProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DataService {
+
+    private final ResilientRestClient restClient;
+    private final DataServiceProperties properties;
+
+    public DataService(ResilientRestClient restClient, DataServiceProperties properties) {
+        this.restClient = restClient;
+        this.properties = properties;
+    }
+
+    public String getUsers() {
+        ResponseEntity<String> response = restClient.get("/users");
+        return response.getBody();
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/client/ResilientRestClient.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/client/ResilientRestClient.java
@@ -1,0 +1,51 @@
+package com.intuit.tsheets.client;
+
+import java.util.Collections;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+
+@Component
+public class ResilientRestClient {
+
+    private final RestClient restClient;
+    private final RetryTemplate retryTemplate;
+
+    public ResilientRestClient(RestClient restClient) {
+        this.restClient = restClient;
+        this.retryTemplate = buildRetryTemplate();
+    }
+
+    private RetryTemplate buildRetryTemplate() {
+        RetryTemplate template = new RetryTemplate();
+        ExponentialBackOffPolicy backOff = new ExponentialBackOffPolicy();
+        backOff.setInitialInterval(200L);
+        backOff.setMultiplier(2.0);
+        backOff.setMaxInterval(2000L);
+        template.setBackOffPolicy(backOff);
+
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(3,
+            Collections.singletonMap(RestClientException.class, true));
+        template.setRetryPolicy(retryPolicy);
+        return template;
+    }
+
+    public ResponseEntity<String> get(String path) {
+        return retryTemplate.execute(context -> restClient.get(path));
+    }
+
+    public ResponseEntity<String> post(String path, Object body) {
+        return retryTemplate.execute(context -> restClient.post(path, body));
+    }
+
+    public ResponseEntity<String> put(String path, Object body) {
+        return retryTemplate.execute(context -> restClient.put(path, body));
+    }
+
+    public ResponseEntity<String> delete(String path) {
+        return retryTemplate.execute(context -> restClient.delete(path));
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/client/RestClient.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/client/RestClient.java
@@ -1,0 +1,55 @@
+package com.intuit.tsheets.client;
+
+import com.intuit.tsheets.config.DataServiceProperties;
+import java.util.Collections;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class RestClient {
+
+    private final RestTemplate restTemplate;
+    private final DataServiceProperties properties;
+
+    public RestClient(RestTemplateBuilder builder, DataServiceProperties properties) {
+        this.restTemplate = builder.build();
+        this.properties = properties;
+    }
+
+    private HttpHeaders defaultHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.USER_AGENT, "TSheets Java SDK");
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + properties.getAuthToken());
+        if (properties.getManagedClientId() != null) {
+            headers.set("X-Managed-Client-Id", properties.getManagedClientId().toString());
+        }
+        return headers;
+    }
+
+    private String url(String path) {
+        return properties.getBaseUrl() + path;
+    }
+
+    public ResponseEntity<String> get(String path) {
+        return restTemplate.exchange(url(path), HttpMethod.GET, new HttpEntity<>(defaultHeaders()), String.class);
+    }
+
+    public ResponseEntity<String> post(String path, Object body) {
+        return restTemplate.exchange(url(path), HttpMethod.POST, new HttpEntity<>(body, defaultHeaders()), String.class);
+    }
+
+    public ResponseEntity<String> put(String path, Object body) {
+        return restTemplate.exchange(url(path), HttpMethod.PUT, new HttpEntity<>(body, defaultHeaders()), String.class);
+    }
+
+    public ResponseEntity<String> delete(String path) {
+        return restTemplate.exchange(url(path), HttpMethod.DELETE, new HttpEntity<>(defaultHeaders()), String.class);
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/config/TSheetsAutoConfiguration.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/config/TSheetsAutoConfiguration.java
@@ -1,10 +1,12 @@
 package com.intuit.tsheets.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ComponentScan("com.intuit.tsheets")
 @EnableConfigurationProperties(DataServiceProperties.class)
-public class CoreAutoConfiguration {
+public class TSheetsAutoConfiguration {
 }
 

--- a/tsheets-core/src/main/resources/META-INF/spring.factories
+++ b/tsheets-core/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.intuit.tsheets.config.CoreAutoConfiguration
+com.intuit.tsheets.config.TSheetsAutoConfiguration
 


### PR DESCRIPTION
## Summary
- add RestClient using RestTemplate with default headers
- add ResilientRestClient with retry template and exponential backoff
- introduce DataService skeleton wired to resilient client
- auto-configure SDK components and properties
- add GitHub Actions workflow to build and test modules

## Testing
- `mvn -q -e install` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b307a6440c832b84ccf42e3ce6ce60