### PR TITLE
feat: add user model and JSON pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Build with Maven
+        run: mvn -q -e install

--- a/tsheets-core/pom.xml
+++ b/tsheets-core/pom.xml
@@ -30,6 +30,17 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/tsheets-core/src/main/java/com/intuit/tsheets/api/DataService.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/api/DataService.java
@@ -1,0 +1,46 @@
+package com.intuit.tsheets.api;
+
+import com.intuit.tsheets.client.EndpointMapper;
+import com.intuit.tsheets.client.EndpointName;
+import com.intuit.tsheets.client.ResilientRestClient;
+import com.intuit.tsheets.config.DataServiceProperties;
+import com.intuit.tsheets.model.User;
+import com.intuit.tsheets.model.UsersResponse;
+import com.intuit.tsheets.pipeline.PipelineContext;
+import com.intuit.tsheets.pipeline.RequestPipeline;
+import com.intuit.tsheets.pipeline.elements.DeserializationElement;
+import com.intuit.tsheets.pipeline.elements.HttpExecutionElement;
+import com.intuit.tsheets.pipeline.elements.SerializationElement;
+import com.intuit.tsheets.pipeline.elements.ValidationElement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DataService {
+
+    private final ResilientRestClient restClient;
+    private final DataServiceProperties properties;
+    private final EndpointMapper endpointMapper;
+
+    public DataService(ResilientRestClient restClient, DataServiceProperties properties, EndpointMapper endpointMapper) {
+        this.restClient = restClient;
+        this.properties = properties;
+        this.endpointMapper = endpointMapper;
+    }
+
+    public List<User> getUsers() {
+        PipelineContext<UsersResponse> context = new PipelineContext<>(EndpointName.USERS, HttpMethod.GET, UsersResponse.class);
+        RequestPipeline pipeline = new RequestPipeline(Arrays.asList(
+            new ValidationElement(),
+            new SerializationElement(),
+            new HttpExecutionElement(restClient, endpointMapper),
+            new DeserializationElement()
+        ));
+        pipeline.execute(context);
+        UsersResponse response = context.getResult();
+        return response != null ? response.getUsers() : Collections.emptyList();
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/client/EndpointMapper.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/client/EndpointMapper.java
@@ -1,0 +1,20 @@
+package com.intuit.tsheets.client;
+
+import java.util.EnumMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EndpointMapper {
+
+    private final Map<EndpointName, String> mapping = new EnumMap<>(EndpointName.class);
+
+    public EndpointMapper() {
+        mapping.put(EndpointName.USERS, "/users");
+        mapping.put(EndpointName.TIMESHEETS, "/timesheets");
+    }
+
+    public String map(EndpointName name) {
+        return mapping.get(name);
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/client/EndpointName.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/client/EndpointName.java
@@ -1,0 +1,6 @@
+package com.intuit.tsheets.client;
+
+public enum EndpointName {
+    USERS,
+    TIMESHEETS;
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/client/ResilientRestClient.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/client/ResilientRestClient.java
@@ -1,0 +1,51 @@
+package com.intuit.tsheets.client;
+
+import java.util.Collections;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+
+@Component
+public class ResilientRestClient {
+
+    private final RestClient restClient;
+    private final RetryTemplate retryTemplate;
+
+    public ResilientRestClient(RestClient restClient) {
+        this.restClient = restClient;
+        this.retryTemplate = buildRetryTemplate();
+    }
+
+    private RetryTemplate buildRetryTemplate() {
+        RetryTemplate template = new RetryTemplate();
+        ExponentialBackOffPolicy backOff = new ExponentialBackOffPolicy();
+        backOff.setInitialInterval(200L);
+        backOff.setMultiplier(2.0);
+        backOff.setMaxInterval(2000L);
+        template.setBackOffPolicy(backOff);
+
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(3,
+            Collections.singletonMap(RestClientException.class, true));
+        template.setRetryPolicy(retryPolicy);
+        return template;
+    }
+
+    public ResponseEntity<String> get(String path) {
+        return retryTemplate.execute(context -> restClient.get(path));
+    }
+
+    public ResponseEntity<String> post(String path, Object body) {
+        return retryTemplate.execute(context -> restClient.post(path, body));
+    }
+
+    public ResponseEntity<String> put(String path, Object body) {
+        return retryTemplate.execute(context -> restClient.put(path, body));
+    }
+
+    public ResponseEntity<String> delete(String path) {
+        return retryTemplate.execute(context -> restClient.delete(path));
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/client/RestClient.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/client/RestClient.java
@@ -1,0 +1,55 @@
+package com.intuit.tsheets.client;
+
+import com.intuit.tsheets.config.DataServiceProperties;
+import java.util.Collections;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class RestClient {
+
+    private final RestTemplate restTemplate;
+    private final DataServiceProperties properties;
+
+    public RestClient(RestTemplateBuilder builder, DataServiceProperties properties) {
+        this.restTemplate = builder.build();
+        this.properties = properties;
+    }
+
+    private HttpHeaders defaultHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.USER_AGENT, "TSheets Java SDK");
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + properties.getAuthToken());
+        if (properties.getManagedClientId() != null) {
+            headers.set("X-Managed-Client-Id", properties.getManagedClientId().toString());
+        }
+        return headers;
+    }
+
+    private String url(String path) {
+        return properties.getBaseUrl() + path;
+    }
+
+    public ResponseEntity<String> get(String path) {
+        return restTemplate.exchange(url(path), HttpMethod.GET, new HttpEntity<>(defaultHeaders()), String.class);
+    }
+
+    public ResponseEntity<String> post(String path, Object body) {
+        return restTemplate.exchange(url(path), HttpMethod.POST, new HttpEntity<>(body, defaultHeaders()), String.class);
+    }
+
+    public ResponseEntity<String> put(String path, Object body) {
+        return restTemplate.exchange(url(path), HttpMethod.PUT, new HttpEntity<>(body, defaultHeaders()), String.class);
+    }
+
+    public ResponseEntity<String> delete(String path) {
+        return restTemplate.exchange(url(path), HttpMethod.DELETE, new HttpEntity<>(defaultHeaders()), String.class);
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/config/TSheetsAutoConfiguration.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/config/TSheetsAutoConfiguration.java
@@ -1,10 +1,12 @@
 package com.intuit.tsheets.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ComponentScan("com.intuit.tsheets")
 @EnableConfigurationProperties(DataServiceProperties.class)
-public class CoreAutoConfiguration {
+public class TSheetsAutoConfiguration {
 }
 

--- a/tsheets-core/src/main/java/com/intuit/tsheets/model/User.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/model/User.java
@@ -1,0 +1,228 @@
+package com.intuit.tsheets.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.OffsetDateTime;
+import javax.validation.constraints.NotBlank;
+
+/**
+ * Represents a TSheets user.
+ */
+public class User {
+
+    @JsonProperty(value = "id", access = JsonProperty.Access.READ_ONLY)
+    private Long id;
+
+    @NotBlank
+    @JsonProperty("first_name")
+    private String firstName;
+
+    @NotBlank
+    @JsonProperty("last_name")
+    private String lastName;
+
+    @JsonProperty("display_name")
+    private String displayName;
+
+    @JsonProperty("pronouns")
+    private String pronouns;
+
+    @JsonProperty("group_id")
+    private Long groupId;
+
+    @JsonProperty("active")
+    private Boolean active;
+
+    @JsonProperty("employee_number")
+    private Long employeeNumber;
+
+    @JsonProperty("salaried")
+    private Boolean salaried;
+
+    @JsonProperty("exempt")
+    private Boolean exempt;
+
+    @NotBlank
+    @JsonProperty("username")
+    private String username;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty(value = "email_verified", access = JsonProperty.Access.READ_ONLY)
+    private Boolean emailVerified;
+
+    @JsonProperty("payroll_id")
+    private String payrollId;
+
+    @JsonProperty("mobile_number")
+    private String mobileNumber;
+
+    @JsonProperty("hire_date")
+    private OffsetDateTime hireDate;
+
+    @JsonProperty("term_date")
+    private OffsetDateTime termDate;
+
+    @JsonProperty(value = "last_modified", access = JsonProperty.Access.READ_ONLY)
+    private OffsetDateTime lastModified;
+
+    @JsonProperty(value = "last_active", access = JsonProperty.Access.READ_ONLY)
+    private OffsetDateTime lastActive;
+
+    @JsonProperty(value = "created", access = JsonProperty.Access.READ_ONLY)
+    private OffsetDateTime created;
+
+    @JsonProperty(value = "client_url", access = JsonProperty.Access.READ_ONLY)
+    private String clientUrl;
+
+    @JsonProperty(value = "company_name", access = JsonProperty.Access.READ_ONLY)
+    private String companyName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getPronouns() {
+        return pronouns;
+    }
+
+    public void setPronouns(String pronouns) {
+        this.pronouns = pronouns;
+    }
+
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(Long groupId) {
+        this.groupId = groupId;
+    }
+
+    public Boolean getActive() {
+        return active;
+    }
+
+    public void setActive(Boolean active) {
+        this.active = active;
+    }
+
+    public Long getEmployeeNumber() {
+        return employeeNumber;
+    }
+
+    public void setEmployeeNumber(Long employeeNumber) {
+        this.employeeNumber = employeeNumber;
+    }
+
+    public Boolean getSalaried() {
+        return salaried;
+    }
+
+    public void setSalaried(Boolean salaried) {
+        this.salaried = salaried;
+    }
+
+    public Boolean getExempt() {
+        return exempt;
+    }
+
+    public void setExempt(Boolean exempt) {
+        this.exempt = exempt;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public Boolean getEmailVerified() {
+        return emailVerified;
+    }
+
+    public String getPayrollId() {
+        return payrollId;
+    }
+
+    public void setPayrollId(String payrollId) {
+        this.payrollId = payrollId;
+    }
+
+    public String getMobileNumber() {
+        return mobileNumber;
+    }
+
+    public void setMobileNumber(String mobileNumber) {
+        this.mobileNumber = mobileNumber;
+    }
+
+    public OffsetDateTime getHireDate() {
+        return hireDate;
+    }
+
+    public void setHireDate(OffsetDateTime hireDate) {
+        this.hireDate = hireDate;
+    }
+
+    public OffsetDateTime getTermDate() {
+        return termDate;
+    }
+
+    public void setTermDate(OffsetDateTime termDate) {
+        this.termDate = termDate;
+    }
+
+    public OffsetDateTime getLastModified() {
+        return lastModified;
+    }
+
+    public OffsetDateTime getLastActive() {
+        return lastActive;
+    }
+
+    public OffsetDateTime getCreated() {
+        return created;
+    }
+
+    public String getClientUrl() {
+        return clientUrl;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/model/UsersResponse.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/model/UsersResponse.java
@@ -1,0 +1,21 @@
+package com.intuit.tsheets.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Wrapper for /users endpoint responses.
+ */
+public class UsersResponse {
+
+    @JsonProperty("users")
+    private List<User> users;
+
+    public List<User> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<User> users) {
+        this.users = users;
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/PipelineContext.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/PipelineContext.java
@@ -1,0 +1,79 @@
+package com.intuit.tsheets.pipeline;
+
+import com.intuit.tsheets.client.EndpointName;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Carries state through the request pipeline.
+ */
+public class PipelineContext<T> {
+
+    private final EndpointName endpoint;
+    private final HttpMethod method;
+    private final Class<T> responseType;
+
+    private Object requestBody;
+    private String serializedRequest;
+    private String responseBody;
+    private T result;
+    private HttpStatus status;
+
+    public PipelineContext(EndpointName endpoint, HttpMethod method, Class<T> responseType) {
+        this.endpoint = endpoint;
+        this.method = method;
+        this.responseType = responseType;
+    }
+
+    public EndpointName getEndpoint() {
+        return endpoint;
+    }
+
+    public HttpMethod getMethod() {
+        return method;
+    }
+
+    public Class<T> getResponseType() {
+        return responseType;
+    }
+
+    public Object getRequestBody() {
+        return requestBody;
+    }
+
+    public void setRequestBody(Object requestBody) {
+        this.requestBody = requestBody;
+    }
+
+    public String getSerializedRequest() {
+        return serializedRequest;
+    }
+
+    public void setSerializedRequest(String serializedRequest) {
+        this.serializedRequest = serializedRequest;
+    }
+
+    public String getResponseBody() {
+        return responseBody;
+    }
+
+    public void setResponseBody(String responseBody) {
+        this.responseBody = responseBody;
+    }
+
+    public T getResult() {
+        return result;
+    }
+
+    public void setResult(T result) {
+        this.result = result;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(HttpStatus status) {
+        this.status = status;
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/PipelineElement.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/PipelineElement.java
@@ -1,0 +1,14 @@
+package com.intuit.tsheets.pipeline;
+
+/**
+ * Element in a request pipeline that can operate on a {@link PipelineContext}.
+ */
+public interface PipelineElement {
+
+    /**
+     * Process the given context, potentially mutating it for the next element in the chain.
+     *
+     * @param context the request/response context
+     */
+    void process(PipelineContext<?> context);
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/RequestPipeline.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/RequestPipeline.java
@@ -1,0 +1,23 @@
+package com.intuit.tsheets.pipeline;
+
+import java.util.List;
+
+public class RequestPipeline {
+
+    private final List<PipelineElement> elements;
+
+    public RequestPipeline(List<PipelineElement> elements) {
+        this.elements = elements;
+    }
+
+    /**
+     * Execute the pipeline against the provided context.
+     *
+     * @param context the context carrying request and response information
+     */
+    public void execute(PipelineContext<?> context) {
+        for (PipelineElement element : elements) {
+            element.process(context);
+        }
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/elements/DeserializationElement.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/elements/DeserializationElement.java
@@ -1,0 +1,30 @@
+package com.intuit.tsheets.pipeline.elements;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.intuit.tsheets.pipeline.PipelineContext;
+import com.intuit.tsheets.pipeline.PipelineElement;
+import java.io.IOException;
+
+/**
+ * Deserializes the response body into the desired type.
+ */
+public class DeserializationElement implements PipelineElement {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Override
+    public void process(PipelineContext<?> context) {
+        String body = context.getResponseBody();
+        Class<?> type = context.getResponseType();
+        if (body != null && type != null) {
+            try {
+                Object result = objectMapper.readValue(body, type);
+                @SuppressWarnings("unchecked")
+                PipelineContext<Object> ctx = (PipelineContext<Object>) context;
+                ctx.setResult(result);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to deserialize response", e);
+            }
+        }
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/elements/HttpExecutionElement.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/elements/HttpExecutionElement.java
@@ -1,0 +1,37 @@
+package com.intuit.tsheets.pipeline.elements;
+
+import com.intuit.tsheets.client.EndpointMapper;
+import com.intuit.tsheets.client.ResilientRestClient;
+import com.intuit.tsheets.pipeline.PipelineContext;
+import com.intuit.tsheets.pipeline.PipelineElement;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+
+public class HttpExecutionElement implements PipelineElement {
+
+    private final ResilientRestClient restClient;
+    private final EndpointMapper endpointMapper;
+
+    public HttpExecutionElement(ResilientRestClient restClient, EndpointMapper endpointMapper) {
+        this.restClient = restClient;
+        this.endpointMapper = endpointMapper;
+    }
+
+    @Override
+    public void process(PipelineContext<?> context) {
+        String path = endpointMapper.map(context.getEndpoint());
+        ResponseEntity<String> response;
+        HttpMethod method = context.getMethod();
+        if (method == HttpMethod.POST) {
+            response = restClient.post(path, context.getSerializedRequest());
+        } else if (method == HttpMethod.PUT) {
+            response = restClient.put(path, context.getSerializedRequest());
+        } else if (method == HttpMethod.DELETE) {
+            response = restClient.delete(path);
+        } else {
+            response = restClient.get(path);
+        }
+        context.setResponseBody(response.getBody());
+        context.setStatus(response.getStatusCode());
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/elements/SerializationElement.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/elements/SerializationElement.java
@@ -1,0 +1,26 @@
+package com.intuit.tsheets.pipeline.elements;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.intuit.tsheets.pipeline.PipelineContext;
+import com.intuit.tsheets.pipeline.PipelineElement;
+
+/**
+ * Serializes the request body using Jackson.
+ */
+public class SerializationElement implements PipelineElement {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Override
+    public void process(PipelineContext<?> context) {
+        Object body = context.getRequestBody();
+        if (body != null) {
+            try {
+                context.setSerializedRequest(objectMapper.writeValueAsString(body));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to serialize request", e);
+            }
+        }
+    }
+}

--- a/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/elements/ValidationElement.java
+++ b/tsheets-core/src/main/java/com/intuit/tsheets/pipeline/elements/ValidationElement.java
@@ -1,0 +1,12 @@
+package com.intuit.tsheets.pipeline.elements;
+
+import com.intuit.tsheets.pipeline.PipelineContext;
+import com.intuit.tsheets.pipeline.PipelineElement;
+
+public class ValidationElement implements PipelineElement {
+
+    @Override
+    public void process(PipelineContext<?> context) {
+        // Placeholder for request validation
+    }
+}

--- a/tsheets-core/src/main/resources/META-INF/spring.factories
+++ b/tsheets-core/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.intuit.tsheets.config.CoreAutoConfiguration
+com.intuit.tsheets.config.TSheetsAutoConfiguration
 

--- a/tsheets-core/src/test/java/com/intuit/tsheets/api/DataServiceTests.java
+++ b/tsheets-core/src/test/java/com/intuit/tsheets/api/DataServiceTests.java
@@ -1,0 +1,55 @@
+package com.intuit.tsheets.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.intuit.tsheets.client.EndpointMapper;
+import com.intuit.tsheets.client.ResilientRestClient;
+import com.intuit.tsheets.client.RestClient;
+import com.intuit.tsheets.config.DataServiceProperties;
+import com.intuit.tsheets.model.User;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestTemplate;
+
+class DataServiceTests {
+
+    private MockRestServiceServer server;
+    private DataService dataService;
+
+    @BeforeEach
+    void setup() throws Exception {
+        DataServiceProperties properties = new DataServiceProperties();
+        properties.setBaseUrl("https://api.example.com");
+        properties.setAuthToken("token");
+
+        RestClient restClient = new RestClient(new RestTemplateBuilder(), properties);
+        ResilientRestClient resilient = new ResilientRestClient(restClient);
+        EndpointMapper mapper = new EndpointMapper();
+        dataService = new DataService(resilient, properties, mapper);
+
+        Field field = RestClient.class.getDeclaredField("restTemplate");
+        field.setAccessible(true);
+        RestTemplate template = (RestTemplate) field.get(restClient);
+        server = MockRestServiceServer.bindTo(template).build();
+    }
+
+    @Test
+    void getUsersRequestsCorrectEndpoint() {
+        server.expect(MockRestRequestMatchers.requestTo("https://api.example.com/users"))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
+            .andRespond(MockRestResponseCreators.withSuccess("{\\"users\\":[{\\"id\\":1,\\"first_name\\":\\"Alice\\",\\"last_name\\":\\"Smith\\",\\"username\\":\\"asmith\\"}]}", MediaType.APPLICATION_JSON));
+
+        List<User> users = dataService.getUsers();
+        assertEquals(1, users.size());
+        assertEquals("Alice", users.get(0).getFirstName());
+        server.verify();
+    }
+}

--- a/tsheets-core/src/test/java/com/intuit/tsheets/client/EndpointMapperTests.java
+++ b/tsheets-core/src/test/java/com/intuit/tsheets/client/EndpointMapperTests.java
@@ -1,0 +1,14 @@
+package com.intuit.tsheets.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class EndpointMapperTests {
+
+    @Test
+    void mapsUsersEndpoint() {
+        EndpointMapper mapper = new EndpointMapper();
+        assertEquals("/users", mapper.map(EndpointName.USERS));
+    }
+}

--- a/tsheets-core/src/test/java/com/intuit/tsheets/pipeline/DeserializationElementTests.java
+++ b/tsheets-core/src/test/java/com/intuit/tsheets/pipeline/DeserializationElementTests.java
@@ -1,0 +1,25 @@
+package com.intuit.tsheets.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.intuit.tsheets.client.EndpointName;
+import com.intuit.tsheets.model.UsersResponse;
+import com.intuit.tsheets.pipeline.elements.DeserializationElement;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+
+class DeserializationElementTests {
+
+    @Test
+    void deserializesUsersResponse() {
+        String json = "{\"users\":[{\"id\":1,\"first_name\":\"Alice\",\"last_name\":\"Smith\",\"username\":\"asmith\"}]}";
+        PipelineContext<UsersResponse> ctx = new PipelineContext<>(EndpointName.USERS, HttpMethod.GET, UsersResponse.class);
+        ctx.setResponseBody(json);
+
+        new DeserializationElement().process(ctx);
+
+        UsersResponse resp = ctx.getResult();
+        assertEquals(1, resp.getUsers().size());
+        assertEquals("Alice", resp.getUsers().get(0).getFirstName());
+    }
+}

--- a/tsheets-core/src/test/java/com/intuit/tsheets/pipeline/SerializationElementTests.java
+++ b/tsheets-core/src/test/java/com/intuit/tsheets/pipeline/SerializationElementTests.java
@@ -1,0 +1,33 @@
+package com.intuit.tsheets.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.intuit.tsheets.client.EndpointName;
+import com.intuit.tsheets.model.User;
+import com.intuit.tsheets.pipeline.elements.SerializationElement;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+
+class SerializationElementTests {
+
+    @Test
+    void serializesUserBody() throws Exception {
+        User user = new User();
+        user.setFirstName("Alice");
+        user.setLastName("Smith");
+        user.setUsername("asmith");
+
+        PipelineContext<Void> ctx = new PipelineContext<>(EndpointName.USERS, HttpMethod.POST, Void.class);
+        ctx.setRequestBody(user);
+
+        new SerializationElement().process(ctx);
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(ctx.getSerializedRequest());
+        assertEquals("Alice", node.get("first_name").asText());
+        assertEquals("Smith", node.get("last_name").asText());
+        assertEquals("asmith", node.get("username").asText());
+    }
+}


### PR DESCRIPTION
## Summary
- extend pipeline context to carry typed results and HTTP status
- add `User` model and JSON (de)serialization elements
- return `List<User>` from `DataService#getUsers` and cover with tests

## Testing
- `mvn -q -pl tsheets-core -am test` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `mvn -q install` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b307a6440c832b84ccf42e3ce6ce60